### PR TITLE
NVIpretty v0.4.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: NVIpretty
 Title: Tools for making R-output pretty in accord with NVI's graphical profile
-Version: 0.4.1
-Date: 2024-11-13
+Version: 0.4.1.9000
+Date: 2024-##-##
 Authors@R: 
   c(person(given = "Petter",
            family = "Hopp",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: NVIpretty
 Title: Tools for making R-output pretty in accord with NVI's graphical profile
-Version: 0.4.1.9000
-Date: 2024-##-##
+Version: 0.4.2
+Date: 2024-12-19
 Authors@R: 
   c(person(given = "Petter",
            family = "Hopp",
@@ -14,7 +14,7 @@ Description: Provides tools for styling output from R in accord with NVI's graph
     tools to format and style output in Excel.
 URL: https://github.com/NorwegianVeterinaryInstitute/NVIpretty
 BugReports: https://github.com/NorwegianVeterinaryInstitute/NVIpretty/issues
-Depends: R (>= 4.0.0)
+Depends: R (>= 4.1.0)
 License: BSD_3_clause + file LICENSE
 Encoding: UTF-8
 LazyData: true
@@ -23,7 +23,7 @@ Imports:
     ggplot2,
     openxlsx,
     NVIcheckmate (>= 0.5.0),
-    NVIdb (>= 0.3.0)
+    NVIdb (>= 0.13.1)
 Suggests:
     covr,
     datasets,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,25 @@
+# NVIpretty 0.4.1.9000 - (2024-##-##)
+
+## New features:
+
+-
+
+
+## Bug fixes:
+
+-
+
+
+## Other changes:
+
+-
+
+
+## BREAKING CHANGES:
+
+-
+
+
 # NVIpretty 0.4.1 - (2024-11-13)
 
 ## Bug fixes:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,23 +1,8 @@
-# NVIpretty 0.4.1.9000 - (2024-##-##)
+# NVIpretty 0.4.2 - (2024-12-19)
 
 ## New features:
 
--
-
-
-## Bug fixes:
-
--
-
-
-## Other changes:
-
--
-
-
-## BREAKING CHANGES:
-
--
+- `add_formatted_worksheet` now accepts `data.frame`, `list` and csv-file as input to the argument `standards`.
 
 
 # NVIpretty 0.4.1 - (2024-11-13)

--- a/R/add_formatted_worksheet.R
+++ b/R/add_formatted_worksheet.R
@@ -24,12 +24,37 @@
 #'     two or more lines. The parameter should be chosen in accord with what looks
 #'     nice depending on column labels and column widths.
 #'
-#'     \code{standards} is the name of the table with column standards. If no
-#'     parameter is given, the columns_standards.csv is used. Column names are
-#'     translated to column labels in accord with the column standards table,
-#'     see \code{standardize_columns}.
+#'     \code{standards} is the name of the table or file with column standards.
+#'     If \code{standards} = \code{NULL} the file "columns_standards.csv" is used.
+#'     Column names are translated to column labels in accord with the column
+#'     standards table, see \code{standardize_columns}.
 #'
-#'     \code{dbsource} is the dbsource in the column standards table making it
+#'     It is also possible to give the standards as a \code{data.frame} or as a
+#'     \code{list}. The list input to column_standards must follow a specific
+#'     format. It is a \code{list} with at least three named vectors:
+#' \itemize{
+#' \item \code{colname}: a vector of all columns in in the source file that
+#'     should be included in the Excel report with the selection list.
+#' \item \code{collabel}: A vector with the labels that should be used in the
+#'     Excel report.
+#' \item \code{colwidth}: A vector with the column width that should be used
+#'     in the Excel report.
+#' }
+#'
+#'     In addition one may input:
+#'
+#' \itemize{
+#' \item \code{colorder}: the order of the columns to be used in the Excel report.
+#'     The default is to use the same order as they are entered in the vectors.
+#' \item \code{column_db}: input added as a possibility to keep on the same format
+#'     as \code{column_standards}. Not necessary to input.
+#' \item \code{table_db}: input added as a possibility to keep on the same format
+#'     as \code{column_standards}. Must be the same as \code{dbsource}. Not
+#'     necessary to input.
+#' }
+#'
+#' All vectors must have the same order and the same length.
+#' #'     \code{dbsource} is the dbsource in the column standards table making it
 #'     possible to tailer the column labels and column widths per table.
 #'
 #' @param data [\code{data.frame}]\cr
@@ -44,8 +69,10 @@
 #'     Should headline be changed to standard labels. Defaults to \code{TRUE}.
 #' @param colwidths [\code{logical(1)}] or \code{"auto"}\cr
 #'     Should defined standard column widths be used. Defaults to \code{TRUE}.
-#' @param standards [\code{data.frame}]\cr
-#'     Tables with column_standards. Defaults to \code{NULL}.
+#' @param standards [\code{data.frame} | \code{list} | \code{character(1)}]\cr
+#' The column standards to be used as input for
+#'     \ifelse{html}{\code{\link[NVIdb]{standardize_columns}}}{\code{NVIdb::standardize_columns}}
+#'     when formatting the Excel sheet columns, see details. Defaults to \code{NULL}.
 #' @param dbsource [\code{character(1)}]\cr
 #'     Database source of data in column standards table. Defaults to name
 #'     of input data.
@@ -96,6 +123,12 @@ add_formatted_worksheet <- function(data, workbook, sheet,
                                     FUN = NULL,
                                     ...) {
 
+  # PREPARE ARGUMENTS BEFORE CHECKING ----
+  if (is.null(standards)) {
+    standards <- file.path(NVIdb::set_dir_NVI("ProgrammeringR", slash = FALSE),
+                           "standardization", "colnames", "column_standards.csv")
+  }
+
   if (!is.null(FUN)) {FUN = match.fun(FUN)}
 
   # ARGUMENT CHECKING ----
@@ -110,8 +143,30 @@ add_formatted_worksheet <- function(data, workbook, sheet,
                                  add = checks)
   checkmate::assert_logical(wrapHeadlineText, add = checks)
   checkmate::assert_logical(collabels, add = checks)
-  checkmate::assert_data_frame(standards, add = checks, null.ok = TRUE)
+  # standards
+  # checkmate::assert_data_frame(standards, add = checks, null.ok = TRUE)
+  checkmate::assert(checkmate::check_class(standards, classes = c("data.frame")),
+                    checkmate::check_class(standards, classes = c("list")),
+                    checkmate::check_class(standards, classes = c("character")),
+                    add = checks)
+  if (inherits(standards, what = "character")) {
+    checkmate::assert_file_exists(standards, add = checks)
+  }
+  if (inherits(standards, what = "list")) {
+    lengths_standard <- lengths(standards)
+    NVIcheckmate::assert_integer(lengths_standard, lower = lengths_standard[1], upper = lengths_standard[1],
+                                 min.len = 3, max.len = 6,
+                                 comment = "When input as a list, all elements must have the same length",
+                                 add = checks)
+    checkmate::assert_subset(names(standards), choices = c("table_db", "colname_db", "colname", "collabel", "colwidth", "colorder"),
+                             add = checks)
+  }
+  if (inherits(standards, what = "data.frame")) {
+    checkmate::assert_data_frame(standards, min.rows = 1, min.cols = 6, add = checks)
+  }
+  # dbsource
   checkmate::assert_character(dbsource, add = checks)
+  # colwidths
   NVIcheckmate::assert(checkmate::check_logical(colwidths),
                        checkmate::check_choice(colwidths, choices = "auto"),
                        combine = "or",

--- a/man/add_formatted_worksheet.Rd
+++ b/man/add_formatted_worksheet.Rd
@@ -36,8 +36,10 @@ Should headline be changed to standard labels. Defaults to \code{TRUE}.}
 \item{colwidths}{[\code{logical(1)}] or \code{"auto"}\cr
 Should defined standard column widths be used. Defaults to \code{TRUE}.}
 
-\item{standards}{[\code{data.frame}]\cr
-Tables with column_standards. Defaults to \code{NULL}.}
+\item{standards}{[\code{data.frame} | \code{list} | \code{character(1)}]\cr
+The column standards to be used as input for
+    \ifelse{html}{\code{\link[NVIdb]{standardize_columns}}}{\code{NVIdb::standardize_columns}}
+    when formatting the Excel sheet columns, see details. Defaults to \code{NULL}.}
 
 \item{dbsource}{[\code{character(1)}]\cr
 Database source of data in column standards table. Defaults to name
@@ -80,12 +82,37 @@ Add excel sheet with a formatted header. The header will be formatted
     two or more lines. The parameter should be chosen in accord with what looks
     nice depending on column labels and column widths.
 
-    \code{standards} is the name of the table with column standards. If no
-    parameter is given, the columns_standards.csv is used. Column names are
-    translated to column labels in accord with the column standards table,
-    see \code{standardize_columns}.
+    \code{standards} is the name of the table or file with column standards.
+    If \code{standards} = \code{NULL} the file "columns_standards.csv" is used.
+    Column names are translated to column labels in accord with the column
+    standards table, see \code{standardize_columns}.
 
-    \code{dbsource} is the dbsource in the column standards table making it
+    It is also possible to give the standards as a \code{data.frame} or as a
+    \code{list}. The list input to column_standards must follow a specific
+    format. It is a \code{list} with at least three named vectors:
+\itemize{
+\item \code{colname}: a vector of all columns in in the source file that
+    should be included in the Excel report with the selection list.
+\item \code{collabel}: A vector with the labels that should be used in the
+    Excel report.
+\item \code{colwidth}: A vector with the column width that should be used
+    in the Excel report.
+}
+
+    In addition one may input:
+
+\itemize{
+\item \code{colorder}: the order of the columns to be used in the Excel report.
+    The default is to use the same order as they are entered in the vectors.
+\item \code{column_db}: input added as a possibility to keep on the same format
+    as \code{column_standards}. Not necessary to input.
+\item \code{table_db}: input added as a possibility to keep on the same format
+    as \code{column_standards}. Must be the same as \code{dbsource}. Not
+    necessary to input.
+}
+
+All vectors must have the same order and the same length.
+#'     \code{dbsource} is the dbsource in the column standards table making it
     possible to tailer the column labels and column widths per table.
 }
 \examples{


### PR DESCRIPTION
`add_formatted_worksheet` now accepts `data.frame`, `list` and csv-file as input to the argument `standards`.